### PR TITLE
Payment request updates if no LAA reference

### DIFF
--- a/app/routes/latest-portal.js
+++ b/app/routes/latest-portal.js
@@ -3,7 +3,7 @@ const router = govukPrototypeKit.requests.setupRouter('/latest-portal')
 
 const version = 'latest-portal'
 
-//Payment type?
+//Ask for LAA reference if payment type is supplemental, appeal or amendment
 router.post('/question-payment-type', function(request, response) {
 
     var paymentType = request.session.data['paymentType']
@@ -13,12 +13,13 @@ router.post('/question-payment-type', function(request, response) {
     } 
 
     if (paymentType == "Non-standard magistrates' - supplemental"){
-        response.redirect('/' + version + "/payments/add/laa-reference?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=60.00&claimedDisbursement=890.00&allowedProfit=332.00&allowedTravel=50.00&allowedWaiting=0.00&allowedDisbursement=890.00")
-    } 
+        response.redirect('/' + version + "/payments/add/original-reference?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=60.00&claimedDisbursement=890.00&allowedProfit=332.00&allowedTravel=50.00&allowedWaiting=0.00&allowedDisbursement=890.00")
+    }
 
     if (paymentType == "Non-standard magistrates' - appeal" | paymentType == "Non-standard magistrates' - amendment") {
-        response.redirect('/' + version + "/payments/add/laa-reference?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=10.00&claimedDisbursement=890.00&allowedProfit=342.00&allowedTravel=0.00&allowedWaiting=10.00&allowedDisbursement=890.00")
+        response.redirect('/' + version + "/payments/add/original-reference?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=10.00&claimedDisbursement=890.00&allowedProfit=342.00&allowedTravel=0.00&allowedWaiting=10.00&allowedDisbursement=890.00")
     } 
+
 
     if (paymentType == "Assigned counsel"){
         response.redirect('/' + version + "/payments/add/linked-claim?officeAccount=&claimedCounselNet=&allowedCounselNet=&claimedCounselVAT=&allowedCounselVAT=")
@@ -29,7 +30,21 @@ router.post('/question-payment-type', function(request, response) {
     } 
   })
 
-  //Payment type?
+  //Skip LAA reference if no LAA reference for the original claim
+router.post('/question-original-reference', function(request, response) {
+
+    var originalReference = request.session.data['originalReference']
+
+    if (originalReference == "No" ){
+        response.redirect('/' + version + "/payments/add/claim-details")
+    } 
+
+    else {
+        response.redirect('/' + version + "/payments/add/laa-reference")
+    } 
+  })
+
+  //Skip LAA reference if assigned counsel claim is not linked to NSM claim
 router.post('/question-linked-claim', function(request, response) {
 
     var linkedCRM7 = request.session.data['linkedCRM7']

--- a/app/views/latest-portal/payments/add/claim-details.html
+++ b/app/views/latest-portal/payments/add/claim-details.html
@@ -26,14 +26,18 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      
+
+<!--Payment type = Non-standard magistrates, Assigned counsel or Non-standard magistrates - Supplemental-->
       {% if data['paymentType'] =="Non-standard magistrates'" or data['paymentType'] =="Assigned counsel" or data['paymentType'] =="Non-standard magistrates' - supplemental" %}
         <form class="form" action="costs-claimed" method="post">
         {% else %}
         <form class="form" action="costs-allowed" method="post">
       {% endif %}
     
+<!--Payment type = Non-standard magistrates - Appeal or Assigned counsel appeal-->
       {% if data['paymentType'] =="Non-standard magistrates' - appeal"  or data['paymentType'] =="Assigned counsel - appeal" %}                            
+<!--Has an LAA ref for original claim-->
+      {% if data['originalReference'] == "Yes" %}
             <!--Date received-->
             {{ mojDatePicker({
               id: "dateReceived",
@@ -48,9 +52,160 @@
                 text: "For example, 17/5/2025."
               }
             }) }}
+            {% endif  %}
+
+<!--Does not have an LAA ref for original reference-->
+          {% if data['originalReference'] == "No" %}
             
-          {% elseif data['paymentType'] =="Non-standard magistrates' - amendment"  or data['paymentType'] =="Assigned counsel - amendment" %}                            
+          <h1 class="govuk-heading-xl">Claim details</h1>  
+
             <!--Date received-->
+            {{ mojDatePicker({
+              id: "dateReceived",
+              name: "dateReceived",
+              label: {
+                text: "Date claim received",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 17/5/2025."
+              }
+            }) }}
+
+            <!--Firm acc-->
+            {% include version +"/includes/list-office-provider.njk"%}
+          
+            <!--UFN-->
+            {{ govukInput({
+              label: {
+                text: "Unique file number",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 120223/001"
+              },
+              id: "ufn",
+              name: "ufn",
+              classes: "govuk-input--width-10"
+            }) }}    
+
+            <!--Stage-->
+            {{ govukRadios({
+              name: "stageReached",
+              fieldset: {
+                legend: {
+                  text: "Stage reached",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "PROG",
+                  text: "PROG"
+                },
+                {
+                  value: "PROM",
+                  text: "PROM"
+                }
+              ]
+            }) }} 
+
+            <!--Defendant first name-->
+            {{ govukInput({
+              label: {
+                text: "Defendant first name",
+                classes: "govuk-label--s"
+              },
+              id: "defendantFirstName",
+              name: "defendantFirstName",
+              classes: "govuk-input--width-20"
+            }) }}    
+
+            <!--Defendant last name-->
+            {{ govukInput({
+              label: {
+                text: "Defendant last name",
+                classes: "govuk-label--s"
+              },
+              id: "defendantLastName",
+              name: "defendantLastName",
+              classes: "govuk-input--width-20"
+            }) }} 
+
+            <!--No defendant-->
+            {{ govukInput({
+              label: {
+                text: "Number of defendants",
+                classes: "govuk-label--s"
+              },
+              id: "defendants",
+              name: "defendants",
+              classes: "govuk-input--width-5"
+            }) }}   
+
+            <!--Hearing attendance-->
+            {{ govukInput({
+              label: {
+                text: "Number of attendances",
+                classes: "govuk-label--s"
+              },
+              id: "attendances",
+              name: "attendances",
+              classes: "govuk-input--width-5"
+            }) }}  
+
+            <!--Hearing outcome not needed? {% include version +"/includes/list-hearing.njk"%}-->
+            <!--Matter type not needed? {% include version +"/includes/list-matter-type.njk"%}-->
+            {% include version +"/includes/list-court.njk"%}  
+
+            <!--Youth Court not needed?
+            {{ govukRadios({
+              name: "youthCourt",
+              fieldset: {
+                legend: {
+                  text: "Is this court a youth court?",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "Yes",
+                  text: "Yes",
+                  checked: checked("youthCourt", "Yes")
+                },
+                {
+                  value: "No",
+                  text: "No",
+                  checked: checked("youthCourt", "No")
+                }
+              ]
+            }) }}-->
+              
+            <!--Date completed-->
+            {{ mojDatePicker({
+              id: "date-completed",
+              name: "date-completed",
+              value: data['date-completed'],
+              label: {
+                text: "Date work completed",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 17/5/2025."
+              }
+            }) }}
+            
+
+
+          {% endif  %}
+            
+<!--Payment type = Non-standard magistrates - Amendment or Assigned counsel amendment-->            
+          {% elseif data['paymentType'] =="Non-standard magistrates' - amendment"  or data['paymentType'] =="Assigned counsel - amendment" %}                            
+<!--Has an LAA ref for original claim-->
+          {% if data['originalReference'] == "Yes" %}  
+          <!--Date received-->
             {{ mojDatePicker({
               id: "dateReceived",
               name: "dateReceived",
@@ -63,8 +218,161 @@
                 text: "For example, 17/5/2025."
               }
             }) }}
-                
+          {% endif  %}
+
+<!--Does not have an LAA ref for original reference-->
+          {% if data['originalReference'] == "No" %}
+            
+          <h1 class="govuk-heading-xl">Claim details</h1>  
+
+            <!--Date received-->
+            {{ mojDatePicker({
+              id: "dateReceived",
+              name: "dateReceived",
+              label: {
+                text: "Date claim received",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 17/5/2025."
+              }
+            }) }}
+
+            <!--Firm acc-->
+            {% include version +"/includes/list-office-provider.njk"%}
+          
+            <!--UFN-->
+            {{ govukInput({
+              label: {
+                text: "Unique file number",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 120223/001"
+              },
+              id: "ufn",
+              name: "ufn",
+              classes: "govuk-input--width-10"
+            }) }}    
+
+            <!--Stage-->
+            {{ govukRadios({
+              name: "stageReached",
+              fieldset: {
+                legend: {
+                  text: "Stage reached",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "PROG",
+                  text: "PROG"
+                },
+                {
+                  value: "PROM",
+                  text: "PROM"
+                }
+              ]
+            }) }} 
+
+            <!--Defendant first name-->
+            {{ govukInput({
+              label: {
+                text: "Defendant first name",
+                classes: "govuk-label--s"
+              },
+              id: "defendantFirstName",
+              name: "defendantFirstName",
+              classes: "govuk-input--width-20"
+            }) }}    
+
+            <!--Defendant last name-->
+            {{ govukInput({
+              label: {
+                text: "Defendant last name",
+                classes: "govuk-label--s"
+              },
+              id: "defendantLastName",
+              name: "defendantLastName",
+              classes: "govuk-input--width-20"
+            }) }} 
+
+            <!--No defendant-->
+            {{ govukInput({
+              label: {
+                text: "Number of defendants",
+                classes: "govuk-label--s"
+              },
+              id: "defendants",
+              name: "defendants",
+              classes: "govuk-input--width-5"
+            }) }}   
+
+            <!--Hearing attendance-->
+            {{ govukInput({
+              label: {
+                text: "Number of attendances",
+                classes: "govuk-label--s"
+              },
+              id: "attendances",
+              name: "attendances",
+              classes: "govuk-input--width-5"
+            }) }}  
+
+            <!--Hearing outcome not needed? {% include version +"/includes/list-hearing.njk"%}-->
+            <!--Matter type not needed? {% include version +"/includes/list-matter-type.njk"%}-->
+            {% include version +"/includes/list-court.njk"%}  
+
+            <!--Youth Court not needed?
+            {{ govukRadios({
+              name: "youthCourt",
+              fieldset: {
+                legend: {
+                  text: "Is this court a youth court?",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "Yes",
+                  text: "Yes",
+                  checked: checked("youthCourt", "Yes")
+                },
+                {
+                  value: "No",
+                  text: "No",
+                  checked: checked("youthCourt", "No")
+                }
+              ]
+            }) }}-->
+              
+            <!--Date completed-->
+            {{ mojDatePicker({
+              id: "date-completed",
+              name: "date-completed",
+              value: data['date-completed'],
+              label: {
+                text: "Date work completed",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 17/5/2025."
+              }
+            }) }}
+            
+
+
+          {% endif  %}
+
+<!--Payment type = Non-standard magistrates - Supplemental-->                
           {% elseif data['paymentType'] =="Non-standard magistrates' - supplemental"  %}
+
+<!--Has an LAA ref for original claim-->
+          {% if data['originalReference'] == "Yes" %}
+
             <!--Date received-->
             {{ mojDatePicker({
               id: "dateReceived",
@@ -78,7 +386,154 @@
                 text: "For example, 17/5/2025."
               }
             }) }}
+            
+          {% endif  %}
 
+<!--Does not have an LAA ref for original reference-->
+          {% if data['originalReference'] == "No" %}
+
+            <h1 class="govuk-heading-xl">Claim details</h1>  
+
+            <!--Date received-->
+            {{ mojDatePicker({
+              id: "dateReceived",
+              name: "dateReceived",
+              label: {
+                text: "Date claim received",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 17/5/2025."
+              }
+            }) }}
+
+            <!--Firm acc-->
+            {% include version +"/includes/list-office-provider.njk"%}
+          
+            <!--UFN-->
+            {{ govukInput({
+              label: {
+                text: "Unique file number",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 120223/001"
+              },
+              id: "ufn",
+              name: "ufn",
+              classes: "govuk-input--width-10"
+            }) }}    
+
+            <!--Stage-->
+            {{ govukRadios({
+              name: "stageReached",
+              fieldset: {
+                legend: {
+                  text: "Stage reached",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "PROG",
+                  text: "PROG"
+                },
+                {
+                  value: "PROM",
+                  text: "PROM"
+                }
+              ]
+            }) }} 
+
+            <!--Defendant first name-->
+            {{ govukInput({
+              label: {
+                text: "Defendant first name",
+                classes: "govuk-label--s"
+              },
+              id: "defendantFirstName",
+              name: "defendantFirstName",
+              classes: "govuk-input--width-20"
+            }) }}    
+
+            <!--Defendant last name-->
+            {{ govukInput({
+              label: {
+                text: "Defendant last name",
+                classes: "govuk-label--s"
+              },
+              id: "defendantLastName",
+              name: "defendantLastName",
+              classes: "govuk-input--width-20"
+            }) }} 
+
+            <!--No defendant-->
+            {{ govukInput({
+              label: {
+                text: "Number of defendants",
+                classes: "govuk-label--s"
+              },
+              id: "defendants",
+              name: "defendants",
+              classes: "govuk-input--width-5"
+            }) }}   
+
+            <!--Hearing attendance-->
+            {{ govukInput({
+              label: {
+                text: "Number of attendances",
+                classes: "govuk-label--s"
+              },
+              id: "attendances",
+              name: "attendances",
+              classes: "govuk-input--width-5"
+            }) }}  
+
+            <!--Hearing outcome not needed? {% include version +"/includes/list-hearing.njk"%}-->
+            <!--Matter type not needed? {% include version +"/includes/list-matter-type.njk"%}-->
+            {% include version +"/includes/list-court.njk"%}
+
+            <!--Youth Court not needed?
+            {{ govukRadios({
+              name: "youthCourt",
+              fieldset: {
+                legend: {
+                  text: "Is this court a youth court?",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "Yes",
+                  text: "Yes",
+                  checked: checked("youthCourt", "Yes")
+                },
+                {
+                  value: "No",
+                  text: "No",
+                  checked: checked("youthCourt", "No")
+                }
+              ]
+            }) }}-->
+              
+            <!--Date completed-->
+            {{ mojDatePicker({
+              id: "date-completed",
+              name: "date-completed",
+              value: data['date-completed'],
+              label: {
+                text: "Date work completed",
+                classes: "govuk-label--s"
+              },
+              hint: {
+                text: "For example, 17/5/2025."
+              }
+            }) }}
+            {% endif %}
+
+<!--Payment type = Assigned counsel-->
           {% elseif data['paymentType'] =="Assigned counsel"  %}
             <h1 class="govuk-heading-xl">Claim details</h1>  
 
@@ -132,7 +587,7 @@
             <!--Counsel acc-->
             {% include version +"/includes/list-office-counsel.njk"%}
 
-          
+<!--Payment type = Non-standard magistrates-->
           {% elseif data['paymentType'] =="Non-standard magistrates'"  %}
             <h1 class="govuk-heading-xl">Claim details</h1>  
 
@@ -236,7 +691,7 @@
             {% include version +"/includes/list-matter-type.njk"%}   
             {% include version +"/includes/list-court.njk"%}  
 
-            <!--Yuoth Court-->
+            <!--Youth Court-->
             {{ govukRadios({
               name: "youthCourt",
               fieldset: {

--- a/app/views/latest-portal/payments/add/original-reference.html
+++ b/app/views/latest-portal/payments/add/original-reference.html
@@ -1,0 +1,104 @@
+{% extends "layouts/main.html" %}
+
+{% set version = "latest-portal" %}
+{% set activePrimeNav = [true, false] %}
+{% set activeSubNav = [false, true, false] %}
+
+
+{% block header %}
+  {% include version +"/includes/header-portal-payments.njk"%}  
+{% endblock %}
+
+{% block pageTitle %}
+  Is there an LAA reference – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "includes/banner.html"%}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form class="form" action="/{{version}}/question-original-reference" method="post">
+      
+      {% if data['paymentType'] =="Non-standard magistrates' - supplemental" or data['paymentType'] =="Non-standard magistrates' - appeal" or data['paymentType'] =="Non-standard magistrates' - amendment"%}    
+        <h1 class="govuk-heading-xl">Is there an LAA reference for the original claim?</h1>
+
+            <!--Check for original LAA reference-->
+            {{ govukRadios({
+              name: "originalReference",
+              fieldset: {
+                legend: {
+                  text: "",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              items: [
+                {
+                  value: "Yes",
+                  text: "Yes",
+                  checked: checked("originalReference", "Yes")
+                },
+                {
+                  value: "No",
+                  text: "No",
+                  checked: checked("originalReference", "No")
+                }
+              ]
+            }) }}
+            
+      {% endif %}
+          
+        <!--buttons-->
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save and continue"
+          }) }}
+
+        </div>
+
+      </form>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block pageScripts %}
+    <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+
+    <script>
+        let selectElements = $('.autocomplete-select')
+        let placeholder = ''
+
+        selectElements.each(function (index) {
+          let selectElement = $(this)
+          if (selectElement.length) {
+            if (selectElement.attr('autocomplete-placeholder')) {
+              placeholder = selectElement.attr('autocomplete-placeholder')
+            }
+
+            accessibleAutocomplete.enhanceSelectElement({
+              confirmOnBlur: false,
+              autoSelect: true,
+              displayMenu: 'overlay',
+              minLength: 1,
+              showNoOptionsFound: true,
+              showAllValues: false,
+              placeholder: placeholder,
+              selectElement: selectElement[0],
+            })
+          }
+        })
+
+    </script>
+
+{% endblock %}


### PR DESCRIPTION
Updating the prototype to account for if there is not an LAA reference when NSM supplemental/appeal/amendment is selected when creating a payment request. Updates are:

- Creating a new page called /original-reference.html in payments area to ask if there is an LAA reference for the original claim when NSM supplemental/appeal/amendment is selected. (Note: I may rename this in future to something better than 'original reference').
- Amendments to /claim-details.html page to account for if there is not an LAA reference when NSM supplemental/appeal/amendment is selected.
- Amendments to the routing to account for if there is not an LAA reference when NSM supplemental/appeal/amendment is selected. Proto should ask for LAA ref if user has selected Yes to laa ref, and proto should skip ref and display a form if user has select No to laa ref.

Note: the code in claim-details needs tidying up when I have more time - there's a lot of repeated code that I believe can be cleaned up but the logic works in the proto for now.