### PR TITLE
Payments request - Search and link the original claim

### DIFF
--- a/app/routes/latest-portal.js
+++ b/app/routes/latest-portal.js
@@ -3,57 +3,73 @@ const router = govukPrototypeKit.requests.setupRouter('/latest-portal')
 
 const version = 'latest-portal'
 
-//Ask for LAA reference if payment type is supplemental, appeal or amendment
-router.post('/question-payment-type', function(request, response) {
+  //Allow user to search for the original claim for all payment types, except Non-standard Magistrates
+  router.post('/question-payment-type', function(request, response) {
 
     var paymentType = request.session.data['paymentType']
 
     if (paymentType == "Non-standard magistrates'" ){
         response.redirect('/' + version + "/payments/add/claim-details?officeAccount=&claimedProfit=&claimedTravel=&claimedWaiting=&claimedDisbursement=&allowedProfit=&allowedTravel=&allowedWaiting=&allowedDisbursement=")
+    }
+    else {
+        response.redirect('/' + version + "/payments/add/laa-reference")
+    } 
+  })
+ 
+//Skip claimed costs for NSM Appeal, NSM Amendment, AC Appeal, AC Amendment
+  router.post('/question-claim-details', function(request, response) {
+
+    var paymentType = request.session.data['paymentType'];
+
+    if (paymentType == "Non-standard magistrates' - supplemental"){
+        response.redirect('/' + version + "/payments/add/costs-claimed?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=60.00&claimedDisbursement=890.00&allowedProfit=332.00&allowedTravel=50.00&allowedWaiting=0.00&allowedDisbursement=890.00")
     } 
 
     if (paymentType == "Non-standard magistrates' - supplemental"){
-        response.redirect('/' + version + "/payments/add/original-reference?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=60.00&claimedDisbursement=890.00&allowedProfit=332.00&allowedTravel=50.00&allowedWaiting=0.00&allowedDisbursement=890.00")
+        response.redirect('/' + version + "/payments/add/costs-claimed")
     }
 
-    if (paymentType == "Non-standard magistrates' - appeal" | paymentType == "Non-standard magistrates' - amendment") {
-        response.redirect('/' + version + "/payments/add/original-reference?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=10.00&claimedDisbursement=890.00&allowedProfit=342.00&allowedTravel=0.00&allowedWaiting=10.00&allowedDisbursement=890.00")
+    if (paymentType == "Non-standard magistrates' - appeal"){
+        response.redirect('/' + version + "/payments/add/costs-allowed?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=60.00&claimedDisbursement=890.00&allowedProfit=332.00&allowedTravel=50.00&allowedWaiting=0.00&allowedDisbursement=890.00")
     } 
 
+    if (paymentType == "Non-standard magistrates' - appeal"){
+        response.redirect('/' + version + "/payments/add/costs-allowed")
+    }
+
+    if (paymentType == "Non-standard magistrates' - amendment"){
+        response.redirect('/' + version + "/payments/add/costs-allowed?claimedProfit=342.00&claimedTravel=0.00&claimedWaiting=60.00&claimedDisbursement=890.00&allowedProfit=332.00&allowedTravel=50.00&allowedWaiting=0.00&allowedDisbursement=890.00")
+    } 
+
+    if (paymentType == "Non-standard magistrates' - amendment"){
+        response.redirect('/' + version + "/payments/add/costs-allowed")
+    }
 
     if (paymentType == "Assigned counsel"){
-        response.redirect('/' + version + "/payments/add/linked-claim?officeAccount=&claimedCounselNet=&allowedCounselNet=&claimedCounselVAT=&allowedCounselVAT=")
+        response.redirect('/' + version + "/payments/add/costs-claimed?claimedCounselNet=1000.00&allowedCounselNet=900.00&claimedCounselVAT=200.00&allowedCounselVAT=180.00")
     } 
+
+    if (paymentType == "Assigned counsel"){
+        response.redirect('/' + version + "/payments/add/costs-claimed")
+    }
+
+    if (paymentType == "Assigned counsel - appeal"){
+        response.redirect('/' + version + "/payments/add/costs-allowed?claimedCounselNet=1000.00&allowedCounselNet=900.00&claimedCounselVAT=200.00&allowedCounselVAT=180.00")
+    } 
+
+    if (paymentType == "Assigned counsel - appeal"){
+        response.redirect('/' + version + "/payments/add/costs-allowed")
+    }
+
+    if (paymentType == "Assigned counsel - amendment"){
+        response.redirect('/' + version + "/payments/add/costs-allowed??claimedCounselNet=1000.00&allowedCounselNet=900.00&claimedCounselVAT=200.00&allowedCounselVAT=180.00")
+    } 
+
+    if (paymentType == "Assigned counsel - amendment"){
+        response.redirect('/' + version + "/payments/add/costs-allowed")
+    }
 
     else {
-        response.redirect('/' + version + "/payments/add/laa-reference?claimedCounselNet=1000.00&allowedCounselNet=900.00&claimedCounselVAT=200.00&allowedCounselVAT=180.00")
-    } 
-  })
-
-  //Skip LAA reference if no LAA reference for the original claim
-router.post('/question-original-reference', function(request, response) {
-
-    var originalReference = request.session.data['originalReference']
-
-    if (originalReference == "No" ){
-        response.redirect('/' + version + "/payments/add/claim-details")
-    } 
-
-    else {
-        response.redirect('/' + version + "/payments/add/laa-reference")
-    } 
-  })
-
-  //Skip LAA reference if assigned counsel claim is not linked to NSM claim
-router.post('/question-linked-claim', function(request, response) {
-
-    var linkedCRM7 = request.session.data['linkedCRM7']
-
-    if (linkedCRM7 == "No" ){
-        response.redirect('/' + version + "/payments/add/claim-details")
-    } 
-
-    else {
-        response.redirect('/' + version + "/payments/add/laa-reference")
+        response.redirect('/' + version + "/payments/add/costs-claimed")
     } 
   })

--- a/app/views/latest-portal/payments/add/claim-details.html
+++ b/app/views/latest-portal/payments/add/claim-details.html
@@ -37,7 +37,7 @@
 <!--Payment type = Non-standard magistrates - Appeal or Assigned counsel appeal-->
       {% if data['paymentType'] =="Non-standard magistrates' - appeal"  or data['paymentType'] =="Assigned counsel - appeal" %}                            
 <!--Has an LAA ref for original claim-->
-      {% if data['originalReference'] == "Yes" %}
+      {% if data['linkedCRM'] == "Yes" %}
             <!--Date received-->
             {{ mojDatePicker({
               id: "dateReceived",
@@ -55,7 +55,7 @@
             {% endif  %}
 
 <!--Does not have an LAA ref for original reference-->
-          {% if data['originalReference'] == "No" %}
+          {% if data['linkedCRM'] == "No" %}
             
           <h1 class="govuk-heading-xl">Claim details</h1>  
 
@@ -204,7 +204,7 @@
 <!--Payment type = Non-standard magistrates - Amendment or Assigned counsel amendment-->            
           {% elseif data['paymentType'] =="Non-standard magistrates' - amendment"  or data['paymentType'] =="Assigned counsel - amendment" %}                            
 <!--Has an LAA ref for original claim-->
-          {% if data['originalReference'] == "Yes" %}  
+          {% if data['linkedCRM'] == "Yes" %}  
           <!--Date received-->
             {{ mojDatePicker({
               id: "dateReceived",
@@ -221,7 +221,7 @@
           {% endif  %}
 
 <!--Does not have an LAA ref for original reference-->
-          {% if data['originalReference'] == "No" %}
+          {% if data['linkedCRM'] == "No" %}
             
           <h1 class="govuk-heading-xl">Claim details</h1>  
 
@@ -371,7 +371,7 @@
           {% elseif data['paymentType'] =="Non-standard magistrates' - supplemental"  %}
 
 <!--Has an LAA ref for original claim-->
-          {% if data['originalReference'] == "Yes" %}
+          {% if data['linkedCRM'] == "Yes" %}
 
             <!--Date received-->
             {{ mojDatePicker({
@@ -390,7 +390,7 @@
           {% endif  %}
 
 <!--Does not have an LAA ref for original reference-->
-          {% if data['originalReference'] == "No" %}
+          {% if data['linkedCRM'] == "No" %}
 
             <h1 class="govuk-heading-xl">Claim details</h1>  
 
@@ -551,7 +551,7 @@
               }) }}
 
 
-            {% if data['linkedCRM7'] == "No" %}
+            {% if data['linkedCRM'] == "No" %}
 
               <!--UFN-->
               {{ govukInput({
@@ -584,8 +584,32 @@
               }) }} 
             {% endif %}
 
-            <!--Counsel acc-->
-            {% include version +"/includes/list-office-counsel.njk"%}
+            <!--Counsel acc with suggestions
+            {% include version +"/includes/list-office-counsel.njk"%}-->
+
+            <!--Counsel office account number-->
+              {{ govukInput({
+                label: {
+                  text: "Counsel office account number",
+                  classes: "govuk-label--s"
+                },
+                id: "officeAccount",
+                name: "officeAccount",
+                classes: "govuk-input--width-20",
+                value: data['officeAccount']
+              }) }} 
+
+            <!--Counsel name-->
+              {{ govukInput({
+                label: {
+                  text: "Counsel name",
+                  classes: "govuk-label--s"
+                },
+                id: "counselName",
+                name: "counselName",
+                classes: "govuk-input--width-20",
+                value: data['counselName']
+              }) }} 
 
 <!--Payment type = Non-standard magistrates-->
           {% elseif data['paymentType'] =="Non-standard magistrates'"  %}

--- a/app/views/latest-portal/payments/add/costs-allowed.html
+++ b/app/views/latest-portal/payments/add/costs-allowed.html
@@ -28,11 +28,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      {% if data['paymentType'] =="Non-standard magistrates'" or data['paymentType'] =="Assigned counsel"%}
-          <h1 class="govuk-heading-xl">Allowed costs</h1>
-        {% else %}
+      {% if data['linkedCRM'] =="Yes"%}
           <h1 class="govuk-heading-xl">Amend allowed costs</h1>
           <p>Amend the totals to show the new allowed costs.</p>
+        {% else %}
+          <h1 class="govuk-heading-xl">Allowed costs</h1>
       {% endif %}
 
       {% if data['paymentType'] =="Assigned counsel" or data['paymentType'] =="Assigned counsel - amendment" or data['paymentType'] =="Assigned counsel - appeal" %}

--- a/app/views/latest-portal/payments/add/costs-claimed.html
+++ b/app/views/latest-portal/payments/add/costs-claimed.html
@@ -27,7 +27,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if data['paymentType'] =="Non-standard magistrates' - supplemental"%}
+      {% if data['linkedCRM'] =="Yes"%}
         <h1 class="govuk-heading-xl">Amend claimed costs</h1>
         <p>Amend the totals to include the supplemental costs</p>
         {% else %}

--- a/app/views/latest-portal/payments/add/laa-reference.html
+++ b/app/views/latest-portal/payments/add/laa-reference.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  Enter Laa reference – {{ serviceName }} – GOV.UK Prototype Kit
+  Search for the claim – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -27,82 +27,247 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        
+      {% if data['paymentType'] == "Assigned counsel"%}
+        <h1 class="govuk-heading-xl">Search for the linked non-standard magistrates claim</h1>
+      {% elseif data['paymentType'] == "Assigned counsel - appeal" or data['paymentType'] == "Assigned counsel - amendment"%}
+        <h1 class="govuk-heading-xl">Search for the original assigned counsel claim</h1>
+      {% else %}
+        <h1 class="govuk-heading-xl">Search for the original claim</h1>
+      {% endif %}
 
-      <form class="form" action="claim-details" method="post">
-
-        {% include version + "/includes/list-laa-ref.html" %}
-
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Save and continue"
-          }) }}
-
+      <div class="moj-search" style="margin-bottom: 20px;">
+        <div class="govuk-form-group" role="search">
+          <label class="govuk-label moj-search__label govuk-!-font-weight-bold" for="filterSearch">
+            Find a claim
+          </label>
+          <div id="search-hint" class="govuk-hint moj-search__hint ">
+            You can search by defendant, firm account, UFN or LAA reference
+          </div>
+          <input class="govuk-input moj-search__input" id="filterSearch" name="filterSearch" type="search" onkeyup="tablefilterSearch()" aria-description="Enter any combination of client or firm name, UFN or LAA reference">
         </div>
-
-      </form>
+        <button type="submit" class="govuk-button moj-search__button" data-module="govuk-button" onclick="mySearch()" id="searchButton">
+          Search
+        </button>
+      </div>
 
     </div>
   </div>
 
-{% endblock %}
+    <form class="form" action="claim-details" method="post">
 
-{% block pageScripts %}
-    <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+      <div id="resultsTable2" style="display:none;">
 
-    <script>
-        let selectElements = $('.autocomplete-select')
-        let placeholder = ''
+      <h2 class="govuk-heading-m" id="resultsHeading">
+        3 search results
+      </h2>
+      
+      <!-- Expose the count in the DOM (Option 2) -->
+      <span id="visibleCount" data-count="3" hidden></span>
 
-        selectElements.each(function (index) {
-          let selectElement = $(this)
-          if (selectElement.length) {
-            if (selectElement.attr('autocomplete-placeholder')) {
-              placeholder = selectElement.attr('autocomplete-placeholder')
-            }
+      <!-- Optional: message that shows when there are zero results -->
+      <div id="noResultsMessage" class="govuk-body" style="display:none;">
+        <p class="govuk-body">Check you've entered the correct details and search again, or create a new digital record for this payment.</p>
+        
+        {{ govukButton({
+          text: "Create new record",
+          name: "linkedCRM",
+          value: "No"
+        }) }}
 
-            accessibleAutocomplete.enhanceSelectElement({
-              confirmOnBlur: false,
-              autoSelect: true,
-              displayMenu: 'overlay',
-              minLength: 1,
-              showNoOptionsFound: true,
-              showAllValues: false,
-              placeholder: placeholder,
-              selectElement: selectElement[0],
-            })
-          }
-        })
+      </div>
 
-        $(function() {
-        $("input[name='courtType']").click(function() {
-          if ($("#courtType").is(":checked")) {
-            $("#div1").show();
-          } else {
-            $("#div1").hide();
-          }
-          if ($("#courtType-3").is(":checked")) {
-            $("#div2").show();
-          } else {
-            $("#div2").hide();
-          }
-        });
-      });
+      <table class="govuk-table generic-filter" id="table-header" data-module="moj-sortable-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header" aria-sort="none">LAA reference</th>
+            <th scope="col" class="govuk-table__header" aria-sort="none">Firm account</th>
+            <th scope="col" class="govuk-table__header" aria-sort="none">Firm name</th>
+            <th scope="col" class="govuk-table__header" aria-sort="none">UFN</th>
+            <th scope="col" class="govuk-table__header" aria-sort="none">Defendant</th>
+            <th scope="col" class="govuk-table__header">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">                
+          <tr class="govuk-table__row hideTR">
+           <td class="govuk-table__cell">LAA-5a7d3c</td> 
+            <td class="govuk-table__cell">1A3BE4</td>
+            <td class="govuk-table__cell">Legal Aiders Ltd</td>
+            <td class="govuk-table__cell">207423/342</td>
+            <td class="govuk-table__cell">Blackbeard</td>
+            <td class="govuk-table__cell">
+              {{ govukButton({
+                text: "Select claim",
+                name: "linkedCRM",
+                value: "Yes"
+              }) }}
+            </td>
+          </tr>
+          <tr class="govuk-table__row hideTR">
+            <td class="govuk-table__cell">LAA-9p4f0e</td> 
+            <td class="govuk-table__cell">1A3BE4</td>
+            <td class="govuk-table__cell">Legal Aiders Ltd</td>
+            <td class="govuk-table__cell">100323/234</td>
+            <td class="govuk-table__cell">Innes</td>
+            <td class="govuk-table__cell">
+              {{ govukButton({
+                text: "Select claim",
+                name: "linkedCRM",
+                value: "Yes"
+              }) }}
+            </td>
+          </tr>
+          <tr class="govuk-table__row hideTR">
+            <td class="govuk-table__cell">LAA-6p4f0r</td>
+            <td class="govuk-table__cell">5T6H7J</td>
+            <td class="govuk-table__cell">Counsel 4U</td>
+            <td class="govuk-table__cell">100323/234</td>
+            <td class="govuk-table__cell">Olu</td>
+            <td class="govuk-table__cell">
+              {{ govukButton({
+                text: "Select claim",
+                name: "linkedCRM",
+                value: "Yes"
+              }) }}
+            </td>
+          </tr>
+        </body>
+      </table>
 
-      window.onload = function(){  
-        if ($("#courtType").is(":checked")) {
-            $("#div1").show();
-          } else {
-            $("#div1").hide();
-          }
-          if ($("#courtType-3").is(":checked")) {
-            $("#div2").show();
-          } else {
-            $("#div2").hide();
-          }
+      {% set pageNo ="0" %}
+      {% include "includes/pagination-search.html"%}
+
+    </div>
+
+    </form>   
+     
+  </div>
+
+</div>
+
+<script>
+  // Toggle results visibility and scroll into view
+  function mySearch() {
+    var searchResult = document.getElementById("resultsTable2");
+
+    if (searchResult.style.display === "none" || searchResult.style.display === "") {
+      searchResult.style.display = "inline";
+      updateVisibleCount(); // ensure initial count is correct when revealed
+    } else {
+      searchResult.style.display = "none";
+    }
+    window.location = '#resultsTable2';
+  }
+
+  // Search that filters rows in a table
+  // https://www.w3schools.com/howto/howto_js_filter_table.asp
+  function tablefilterSearch() {
+    var input = document.getElementById("filterSearch");
+    var filter = input.value.toUpperCase();
+    var table = document.getElementsByClassName("generic-filter")[0];
+    var tr = table.getElementsByTagName("tr");
+
+    for (var i = 0; i < tr.length; i++) {
+      var td = tr[i].getElementsByTagName("td");
+      if (td.length > 0) { // skip header rows
+        if (
+          td[0].innerHTML.toUpperCase().indexOf(filter) > -1 ||
+          td[1].innerHTML.toUpperCase().indexOf(filter) > -1 ||
+          td[2].innerHTML.toUpperCase().indexOf(filter) > -1
+        ) {
+          tr[i].style.display = "";
+        } else {
+          tr[i].style.display = "none";
         }
+      }
+    }
+    updateVisibleCount(); // recalc after filtering
+  }
 
-       
-         
-    </script>
+  // Filters the table based on specific properties that are not in the table data.
+  // https://www.w3schools.com/howto/howto_js_filter_elements.asp
+  filterSelection("all");
+  function filterSelection(c) {
+    var x = document.getElementsByClassName("hideTR");
+    if (c == "all") c = "";
+    for (var i = 0; i < x.length; i++) {
+      w3RemoveClass(x[i], "showTR");
+      if (x[i].className.indexOf(c) > -1) w3AddClass(x[i], "showTR");
+    }
+    updateVisibleCount(); // recalc if you use class-based filtering too
+  }
 
+  function w3AddClass(element, name) {
+    var arr1 = element.className.split(" ");
+    var arr2 = name.split(" ");
+    for (var i = 0; i < arr2.length; i++) {
+      if (arr1.indexOf(arr2[i]) == -1) { element.className += " " + arr2[i]; }
+    }
+  }
+
+  function w3RemoveClass(element, name) {
+    var arr1 = element.className.split(" ");
+    var arr2 = name.split(" ");
+    for (var i = 0; i < arr2.length; i++) {
+      while (arr1.indexOf(arr2[i]) > -1) {
+        arr1.splice(arr1.indexOf(arr2[i]), 1);
+      }
+    }
+    element.className = arr1.join(" ");
+  }
+
+  // Highlight the active filter button
+  var btnContainer = document.getElementById("filterbuttonContainer");
+  if (btnContainer) {
+    var btns = btnContainer.getElementsByClassName("govuk-button--secondary");
+    for (var i = 0; i < btns.length; i++) {
+      btns[i].addEventListener("click", function() {
+        var current = document.getElementsByClassName("active");
+        if (current[0]) current[0].className = current[0].className.replace(" active", "");
+        this.className += " active";
+      });
+    }
+  }
+
+  // ===== Shared count updater =====
+  function updateVisibleCount() {
+    var rows = document.querySelectorAll("#table-header tbody tr");
+    var visibleCount = 0;
+
+    rows.forEach(function(row) {
+      // count only data rows and only if actually visible (covers style or class hiding)
+      if (row.getElementsByTagName("td").length === 0) return;
+      var display = window.getComputedStyle(row).display;
+      if (display !== "none") visibleCount++;
+    });
+
+    // Update heading text
+    var resultHeading = document.getElementById("resultsHeading");
+    if (resultHeading) {
+      resultHeading.textContent = (visibleCount === 0)
+        ? "There are no results that match the search criteria"
+        : visibleCount + " search results";
+    }
+
+    // Expose count in the DOM (Option 2)
+    var countEl = document.getElementById("visibleCount");
+    if (countEl) {
+      countEl.setAttribute("data-count", visibleCount);
+    }
+
+    // Optional: show/hide "no results" helper text
+    var noMsg = document.getElementById("noResultsMessage");
+    if (noMsg) {
+      noMsg.style.display = (visibleCount === 0) ? "block" : "none";
+    }
+
+    // Also expose globally if you want to use elsewhere in JS
+    window.visibleRows = visibleCount;
+  }
+
+  // On initial load, compute the correct starting count
+  document.addEventListener("DOMContentLoaded", function() {
+    updateVisibleCount();
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
Changing the design and flow of making a payment request.

Removing the question 'Is there an LAA reference for the original claim?' and the autocomplete suggestions box for finding the LAA reference for the original claim. Replacing this with a new screen called 'Search for the original claim' which uses an inline search to allow users to either find and link a claim, or continue without linking and create a new digital record.