### PR TITLE
CRM457-0000: SCA flagged vulnerabilities addressed. Immutable changed to 4.3.9 as it was the patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@x-govuk/govuk-prototype-filters": "2.0.0",
         "accessible-autocomplete": "^2.0.4",
         "govuk-frontend": "5.11.1",
-        "govuk-prototype-kit": "13.20.2",
+        "govuk-prototype-kit": "13.20.3",
         "jquery": "3.7.1",
         "notifications-node-client": "8.4.0"
       }
@@ -334,9 +334,9 @@
       }
     },
     "node_modules/govuk-prototype-kit": {
-      "version": "13.20.2",
-      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-13.20.2.tgz",
-      "integrity": "sha512-GkDvGk0ImdfijFDp96jA0Wwhb3NHNVQAfBZzavVadhBO231Pfl/6d0uhmi09qXVZxp1CLFuTzxjeqPiOnPEZvQ==",
+      "version": "13.20.3",
+      "resolved": "https://registry.npmjs.org/govuk-prototype-kit/-/govuk-prototype-kit-13.20.3.tgz",
+      "integrity": "sha512-Z/Aqx5xmbRuR9jzIFRO+3SRRcwYAzkVy9mbUnUZk+576Xt+f3T4WdxpD+YjAU6F6T//337UMqhHmn7spYsR8Dg==",
       "hasShrinkwrap": true,
       "dependencies": {
         "@inquirer/confirm": "^5.1.15",
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/govuk-prototype-kit/node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -1083,9 +1083,9 @@
       }
     },
     "node_modules/govuk-prototype-kit/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3106,9 +3106,9 @@
       }
     },
     "node_modules/govuk-prototype-kit/node_modules/sass/node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/govuk-prototype-kit/node_modules/sass/node_modules/readdirp": {
@@ -3545,9 +3545,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-prototype-kit/node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,24 +13,26 @@
     "@x-govuk/govuk-prototype-filters": "2.0.0",
     "accessible-autocomplete": "^2.0.4",
     "govuk-frontend": "5.11.1",
-    "govuk-prototype-kit": "13.20.2",
+    "govuk-prototype-kit": "13.20.3",
     "jquery": "3.7.1",
     "notifications-node-client": "8.4.0"
   },
   "overrides": {
     "axios": "1.18.1",
     "form-data": "4.0.6",
+    "brace-expansion": "5.0.8",
+    "immutable": "5.1.9",
     "jws": "3.2.3",
     "lodash": "4.18.1",
     "govuk-prototype-kit": {
       "lodash": "4.18.1",
-      "immutable": "3.8.3",
+      "immutable": "5.1.9",
       "minimatch": "3.1.5",
       "path-to-regexp": "0.1.13",
       "picomatch": "2.3.2",
-      "socket.io-parser": "4.2.6",
+      "socket.io-parser": "4.2.7",
       "sass": {
-        "immutable": "5.1.5"
+        "immutable": "5.1.9"
       }
     }
   }


### PR DESCRIPTION
The SCA scan identified several high-severity vulnerabilities in transitive dependencies, with no critical issues reported, and the affected packages were upgraded and pinned to patched releases accordingly.